### PR TITLE
RBN 41: Responsive header with menu items

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/images/pdlogo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no"
+    />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/src/assets/menu.svg
+++ b/src/assets/menu.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="14" viewBox="0 0 21 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 14V11.6667H14.875V14H0ZM0 8.16667V5.83333H21V8.16667H0ZM0 2.33333V0H21V2.33333H0Z" fill="#0A0C0E"/>
+</svg>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -63,3 +63,90 @@
   position: relative;
   margin-left: 30px;
 }
+
+.searchWrapper {
+  height: 48px;
+  margin-top: 48px;
+}
+
+@media (max-width: 1000px) {
+  .searchTextField ::placeholder {
+    font-weight: 600;
+    font-size: 16px;
+  }
+
+  .searchTextField {
+    margin-left: 0;
+    padding-bottom: 15px;
+  }
+
+  .closeBar {
+    height: 80px;
+    background-color: #0a0c0e;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .closeIcon {
+    color: #ffffff;
+    padding: 28px 28px 28px 0;
+  }
+
+  .menuWrapper {
+    padding: 48px 32px 0px 32px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  .menuItemsWrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    padding-top: 48px;
+  }
+
+  .menuItemsText {
+    font-size: 24px;
+    font-weight: 600;
+  }
+
+  .maxWidth {
+    width: 100vw;
+  }
+
+  .searchIconWrapper {
+    padding-left: 0;
+  }
+
+  .loggedUsername {
+    font-weight: 600;
+    font-size: 16px;
+    padding-top: 20px;
+  }
+
+  .loggedEmail {
+    font-weight: 400;
+    font-size: 14px;
+    padding-bottom: 22px;
+    color: #646d75;
+  }
+
+  .logoutWrapper {
+    display: flex;
+    flex-direction: row;
+    padding-top: 32px;
+  }
+
+  .logoutIcon {
+    font-size: 18px;
+    padding-right: 8px;
+    padding-top: 1px;
+  }
+
+  .logoutText {
+    font-weight: 400;
+    font-size: 14px;
+  }
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -149,4 +149,17 @@
     font-weight: 400;
     font-size: 14px;
   }
+
+  .notificationBadgeResponsive {
+    background: #ea592a;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-left: 141px;
+    margin-top: -25px;
+  }
+
+  .notificationWrapperResponsive {
+    margin-left: 0;
+  }
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -69,97 +69,44 @@
   margin-top: 48px;
 }
 
-@media (max-width: 1000px) {
-  .searchTextField ::placeholder {
-    font-weight: 600;
-    font-size: 16px;
+.menuWrapperButton {
+  @media (min-width: 780px) {
+    display: none;
+  }
+}
+
+@media (max-width: 780px) {
+  .menuItems {
+    display: none;
   }
 
   .searchTextField {
-    margin-left: 0;
-    padding-bottom: 15px;
+    display: none;
   }
 
-  .closeBar {
-    height: 80px;
-    background-color: #0a0c0e;
+  .toolBar {
     display: flex;
-    justify-content: flex-end;
-  }
-
-  .closeIcon {
-    color: #ffffff;
-    padding: 28px 28px 28px 0;
-  }
-
-  .menuWrapper {
-    padding: 48px 32px 0px 32px;
-    display: flex;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: space-between;
-    height: 100%;
   }
 
-  .menuItemsWrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 40px;
-    padding-top: 48px;
+  .menuWrapperButton {
+    margin-inline: 20px;
+  }
+}
+
+@media (max-width: 1094px) {
+  .logo {
+    margin-left: 32px;
+    margin-right: 20px;
   }
 
   .menuItemsText {
-    font-size: 24px;
-    font-weight: 600;
-  }
-
-  .maxWidth {
-    width: 100vw;
-  }
-
-  .searchIconWrapper {
     padding-left: 0;
+    padding-right: 0;
   }
 
-  .loggedUsername {
-    font-weight: 600;
-    font-size: 16px;
-    padding-top: 20px;
-  }
-
-  .loggedEmail {
-    font-weight: 400;
-    font-size: 14px;
-    padding-bottom: 22px;
-    color: #646d75;
-  }
-
-  .logoutWrapper {
-    display: flex;
-    flex-direction: row;
-    padding-top: 32px;
-  }
-
-  .logoutIcon {
-    font-size: 18px;
-    padding-right: 8px;
-    padding-top: 1px;
-  }
-
-  .logoutText {
-    font-weight: 400;
-    font-size: 14px;
-  }
-
-  .notificationBadgeResponsive {
-    background: #ea592a;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    margin-left: 141px;
-    margin-top: -25px;
-  }
-
-  .notificationWrapperResponsive {
-    margin-left: 0;
+  .searchTextField {
+    margin-left: 25px;
   }
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -93,6 +93,14 @@
   .menuWrapperButton {
     margin-inline: 20px;
   }
+
+  .appBar {
+    height: 96px;
+  }
+
+  .toolBar {
+    height: 96px;
+  }
 }
 
 @media (max-width: 1094px) {

--- a/src/components/Header/MenuItems.tsx
+++ b/src/components/Header/MenuItems.tsx
@@ -13,7 +13,7 @@ import avatar from '../../assets/avatar.svg'
 import styles from './Header.module.css'
 import { useState } from 'react'
 import menuIcon from '../../assets/menu.svg'
-import SideBar from './SideBar/SideBar'
+import { SideBar } from './SideBar'
 
 export const MenuItems = () => {
   const [open, setOpen] = useState(false)

--- a/src/components/Header/MenuItems.tsx
+++ b/src/components/Header/MenuItems.tsx
@@ -13,7 +13,7 @@ import avatar from '../../assets/avatar.svg'
 import styles from './Header.module.css'
 import { useState } from 'react'
 import menuIcon from '../../assets/menu.svg'
-import SideBar from './SideBar'
+import SideBar from './SideBar/SideBar'
 
 export const MenuItems = () => {
   const [open, setOpen] = useState(false)
@@ -25,6 +25,7 @@ export const MenuItems = () => {
   return (
     <>
       <Stack
+        className={styles.menuItems}
         direction='row'
         spacing='48px'
         marginLeft='auto'

--- a/src/components/Header/MenuItems.tsx
+++ b/src/components/Header/MenuItems.tsx
@@ -1,5 +1,6 @@
 import {
   Avatar,
+  Button,
   Divider,
   IconButton,
   MenuItem,
@@ -10,8 +11,17 @@ import SearchIcon from '@mui/icons-material/Search'
 import avatar from '../../assets/avatar.svg'
 
 import styles from './Header.module.css'
+import { useState } from 'react'
+import menuIcon from '../../assets/menu.svg'
+import SideBar from './SideBar'
 
 export const MenuItems = () => {
+  const [open, setOpen] = useState(false)
+
+  const toggleDrawer = (newOpen: boolean) => () => {
+    setOpen(newOpen)
+  }
+
   return (
     <>
       <Stack
@@ -51,6 +61,11 @@ export const MenuItems = () => {
           },
         }}
       ></TextField>
+
+      <Button className={styles.menuWrapperButton} onClick={toggleDrawer(true)}>
+        <img src={menuIcon} alt='menu-icon' />
+      </Button>
+      <SideBar open={open} toggleDrawer={toggleDrawer(false)} />
     </>
   )
 }

--- a/src/components/Header/SideBar.tsx
+++ b/src/components/Header/SideBar.tsx
@@ -1,0 +1,86 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  IconButton,
+  TextField,
+  Typography,
+} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
+import CloseIcon from '@mui/icons-material/Close'
+import LogoutIcon from '@mui/icons-material/Logout'
+
+import styles from './Header.module.css'
+
+interface SidebarProps {
+  open: boolean
+  toggleDrawer: (newOpen: boolean) => void
+}
+const SideBar = ({ open, toggleDrawer }: SidebarProps) => {
+  const DrawerList = (
+    <Box className={styles.outerBox} sx={{ width: '100%' }} role='presentation'>
+      <div className={styles.closeBar}>
+        <Button onClick={() => toggleDrawer(false)}>
+          <CloseIcon className={styles.closeIcon}></CloseIcon>
+        </Button>
+      </div>
+
+      <div className={styles.menuWrapper}>
+        <div>
+          <TextField
+            id='standard-basic'
+            variant='standard'
+            className={styles.searchTextField}
+            placeholder='Search'
+            slotProps={{
+              input: {
+                disableUnderline: true,
+                startAdornment: (
+                  <IconButton className={styles.searchIconWrapper}>
+                    <SearchIcon className={styles.searchIcon} />
+                  </IconButton>
+                ),
+              },
+            }}
+          ></TextField>
+          <Divider />
+          <div className={styles.menuItemsWrapper}>
+            <Typography className={styles.menuItemsText}>Library</Typography>
+            <Typography className={styles.menuItemsText}>My books</Typography>
+            <Typography className={styles.menuItemsText}>Help</Typography>
+            <Typography className={styles.menuItemsText}>
+              Notifications
+            </Typography>
+          </div>
+        </div>
+        <div className={styles.loginWrapper}>
+          <Divider />
+
+          <Typography className={styles.loggedUsername}>
+            Milena Pavlovic
+          </Typography>
+          <Typography className={styles.loggedEmail}>
+            milena.pavlovic@productdock.com
+          </Typography>
+          <Divider />
+          <div className={styles.logoutWrapper}>
+            <LogoutIcon className={styles.logoutIcon} />
+            <Typography className={styles.logoutText}>Sign out</Typography>
+          </div>
+        </div>
+      </div>
+    </Box>
+  )
+  return (
+    <Drawer
+      className={styles.sideBarDrawer}
+      sx={{ '& .MuiDrawer-paper': { width: '100%' } }}
+      open={open}
+      onClose={() => toggleDrawer(false)}
+    >
+      {DrawerList}
+    </Drawer>
+  )
+}
+export default SideBar

--- a/src/components/Header/SideBar.tsx
+++ b/src/components/Header/SideBar.tsx
@@ -49,14 +49,16 @@ const SideBar = ({ open, toggleDrawer }: SidebarProps) => {
             <Typography className={styles.menuItemsText}>Library</Typography>
             <Typography className={styles.menuItemsText}>My books</Typography>
             <Typography className={styles.menuItemsText}>Help</Typography>
-            <Typography className={styles.menuItemsText}>
-              Notifications
-            </Typography>
+            <div className={styles.notificationWrapperResponsive}>
+              <span className={styles.menuItemsText}>Notifications</span>
+              <span>
+                <div className={styles.notificationBadgeResponsive} />
+              </span>
+            </div>
           </div>
         </div>
         <div className={styles.loginWrapper}>
           <Divider />
-
           <Typography className={styles.loggedUsername}>
             Milena Pavlovic
           </Typography>

--- a/src/components/Header/SideBar/SideBar.module.css
+++ b/src/components/Header/SideBar/SideBar.module.css
@@ -1,0 +1,105 @@
+.sideBarDrawer {
+  @media (min-width: 780px) {
+    display: none;
+  }
+}
+
+@media (max-width: 1000px) {
+  .searchTextField ::placeholder {
+    font-weight: 600;
+    font-size: 16px;
+    color: #0a0c0e;
+    opacity: 1;
+  }
+
+  .searchTextField {
+    margin-left: 0;
+    padding-bottom: 15px;
+  }
+
+  .closeBar {
+    height: 80px;
+    background-color: #0a0c0e;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .closeIcon {
+    color: #ffffff;
+    padding: 28px 28px 28px 0;
+  }
+
+  .menuWrapper {
+    padding: 48px 32px 0px 32px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  .menuItemsWrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    padding-top: 48px;
+  }
+
+  .menuItemsText {
+    font-size: 24px;
+    font-weight: 600;
+    color: #0a0c0e;
+  }
+
+  .maxWidth {
+    width: 100vw;
+  }
+
+  .searchIconWrapper {
+    padding-left: 0;
+    color: #0a0c0e;
+  }
+
+  .loggedUsername {
+    font-weight: 600;
+    font-size: 16px;
+    padding-top: 20px;
+  }
+
+  .loggedEmail {
+    font-weight: 400;
+    font-size: 14px;
+    padding-bottom: 22px;
+    color: #646d75;
+  }
+
+  .logoutWrapper {
+    display: flex;
+    flex-direction: row;
+    padding-top: 32px;
+  }
+
+  .logoutIcon {
+    font-size: 18px;
+    padding-right: 8px;
+    padding-top: 1px;
+  }
+
+  .logoutText {
+    font-weight: 400;
+    font-size: 14px;
+    padding-bottom: 48px;
+  }
+
+  .notificationBadgeResponsive {
+    background: #ea592a;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-left: 141px;
+    margin-top: -25px;
+  }
+
+  .notificationWrapperResponsive {
+    margin-left: 0;
+  }
+}

--- a/src/components/Header/SideBar/SideBar.tsx
+++ b/src/components/Header/SideBar/SideBar.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Divider,
   Drawer,
@@ -11,7 +10,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import CloseIcon from '@mui/icons-material/Close'
 import LogoutIcon from '@mui/icons-material/Logout'
 
-import styles from './Header.module.css'
+import styles from './SideBar.module.css'
 
 interface SidebarProps {
   open: boolean
@@ -19,7 +18,7 @@ interface SidebarProps {
 }
 const SideBar = ({ open, toggleDrawer }: SidebarProps) => {
   const DrawerList = (
-    <Box className={styles.outerBox} sx={{ width: '100%' }} role='presentation'>
+    <>
       <div className={styles.closeBar}>
         <Button onClick={() => toggleDrawer(false)}>
           <CloseIcon className={styles.closeIcon}></CloseIcon>
@@ -72,7 +71,7 @@ const SideBar = ({ open, toggleDrawer }: SidebarProps) => {
           </div>
         </div>
       </div>
-    </Box>
+    </>
   )
   return (
     <Drawer

--- a/src/components/Header/SideBar/index.ts
+++ b/src/components/Header/SideBar/index.ts
@@ -1,0 +1,1 @@
+export { default as SideBar } from './SideBar'

--- a/src/pages/Homepage/LetsStartExploring/LetsStartExploring.module.css
+++ b/src/pages/Homepage/LetsStartExploring/LetsStartExploring.module.css
@@ -15,4 +15,27 @@
 
 .text {
   font-size: 96px;
+  font-weight: 600;
+}
+
+@media (max-width: 1094px) {
+  .wrapper {
+    margin-left: 100px;
+  }
+}
+
+@media (max-width: 600px) {
+  .wrapper {
+    margin-left: 32px;
+    margin-top: 44px;
+  }
+
+  .text {
+    font-size: 48px;
+  }
+
+  .dot {
+    font-size: 48px;
+    font-weight: 800;
+  }
 }


### PR DESCRIPTION
<!-- Comments will not displayed in the body. -->

### What did you implement?

Implemented responsive header with sidebar which displays all menu items, for different screen sizes, as well as responsive design for 'Let's start exploring' component.

### How can we verify the changes?

Changes can be verified by running the app and checking if header displays hamburger menu on certain screen width, clicking on it should open sidebar with menu icons.
### More info

- Jira: [RBN-41](https://productdock.atlassian.net/browse/RBN-41)

- Figma: [Design](https://www.figma.com/design/x4SgW80BE24s9gAFHM3gXS/RBC---Novi-Sad%2C-2024?node-id=4502-11397&t=IOmX0P558BlJXDSW-4)
